### PR TITLE
When a channel closes, isClosed remains false

### DIFF
--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -138,7 +138,9 @@ public final class WebSocket: BasicWorker {
 
     /// A `Future` that will be completed when the `WebSocket` closes.
     public var onClose: Future<Void> {
-        return channel.closeFuture
+        return channel.closeFuture.always { [weak self] in
+            self?.isClosed = true
+        }
     }
 
     /// Closes the `WebSocket`'s connection, disconnecting the client.


### PR DESCRIPTION
Fixed an issue where `isClosed` is never mutated and will always remain `false`, regardless of if the `Channel` closes or not. 

Example:

```swift
let worker = MultiThreadedEventLoopGroup(numThreads: 1)
let ws = try HTTPClient.webSocket(scheme: .wss, hostname: url.host, port: url.port, path: url.path, on: worker).wait()
...
// Schedule a ping job
Jobs.add(interval: .seconds(4)) {
    guard !ws.isClosed, connected else { return }

    // send keepalive ping
    ws.send("ping")
}
...
try ws.onClose..wait()
```