### PR TITLE
add support for websocket close code; other bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /Packages
 /*.xcodeproj
 Package.resolved
+DerivedData
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
     dependencies: [
         // 🌎 Utility package containing tools for byte manipulation, Codable, OS APIs, and debugging.
         .package(url: "https://github.com/vapor/core.git", from: "3.0.0"),
+
+        // 🔑 Hashing (BCrypt, SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
+        .package(url: "https://github.com/vapor/crypto.git", from: "3.0.0"),
         
         // 🚀 Non-blocking, event-driven HTTP for Swift built on Swift NIO.
         .package(url: "https://github.com/vapor/http.git", from: "3.0.0"),
@@ -20,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.1"),
     ],
     targets: [
-        .target(name: "WebSocket", dependencies: ["Core", "HTTP", "NIO", "NIOWebSocket"]),
+        .target(name: "WebSocket", dependencies: ["Core", "Crypto", "HTTP", "NIO", "NIOWebSocket"]),
         .testTarget(name: "WebSocketTests", dependencies: ["WebSocket"]),
     ]
 )

--- a/Sources/WebSocket/WebSocket+Client.swift
+++ b/Sources/WebSocket/WebSocket+Client.swift
@@ -75,7 +75,7 @@ private final class WebSocketClientUpgrader: HTTPClientProtocolUpgrader {
             let webSocketKey = try CryptoRandom().generateData(count: 16).base64EncodedString()
             upgradeReq.headers.add(name: .secWebSocketKey, value: webSocketKey)
         } catch {
-            print("[WebSocket] [Upgrader] Could not generate random value for Sec-WebSocket-Key header.")
+            print("[WebSocket] [Upgrader] Could not generate random value for Sec-WebSocket-Key header: \(error)")
         }
         return upgradeReq
     }

--- a/Sources/WebSocket/WebSocket+Client.swift
+++ b/Sources/WebSocket/WebSocket+Client.swift
@@ -1,3 +1,5 @@
+import Crypto
+
 /// Allows `HTTPClient` to be used to create `WebSocket` connections.
 ///
 ///     let ws = try HTTPClient.webSocket(hostname: "echo.websocket.org", on: ...).wait()
@@ -68,8 +70,13 @@ private final class WebSocketClientUpgrader: HTTPClientProtocolUpgrader {
         upgradeReq.headers.add(name: .upgrade, value: "websocket")
         upgradeReq.headers.add(name: .host, value: hostname)
         upgradeReq.headers.add(name: .origin, value: "vapor/websocket")
-        upgradeReq.headers.add(name: .secWebSocketVersion, value: "13") // fixme: randomly gen
-        upgradeReq.headers.add(name: .secWebSocketKey, value: "MTMtMTUyMzk4NDIxNzk3NQ==") // fixme: randomly gen
+        upgradeReq.headers.add(name: .secWebSocketVersion, value: "13")
+        do {
+            let webSocketKey = try CryptoRandom().generateData(count: 16).base64EncodedString()
+            upgradeReq.headers.add(name: .secWebSocketKey, value: webSocketKey)
+        } catch {
+            print("[WebSocket] [Upgrader] Could not generate random value for Sec-WebSocket-Key header.")
+        }
         return upgradeReq
     }
 

--- a/Sources/WebSocket/WebSocket+Server.swift
+++ b/Sources/WebSocket/WebSocket+Server.swift
@@ -21,11 +21,18 @@ extension HTTPServer {
     ///
     ///     HTTPServer.start(..., upgraders: [ws])
     ///
+    /// - parameters:
+    ///     - maxFrameSize: Maximum WebSocket frame size this server will accept.
+    ///     - shouldUpgrade: Called when an incoming HTTPRequest attempts to upgrade.
+    ///                      Return non-nil headers to accept the upgrade.
+    ///     - onUpgrade: Called when a new WebSocket client has connected.
+    /// - returns: An `HTTPProtocolUpgrader` for use with `HTTPServer`.
     public static func webSocketUpgrader(
+        maxFrameSize: Int = 1 << 14,
         shouldUpgrade: @escaping (HTTPRequest) -> (HTTPHeaders?),
         onUpgrade: @escaping (WebSocket, HTTPRequest) -> ()
     ) -> HTTPProtocolUpgrader {
-        return WebSocketUpgrader(shouldUpgrade: { head in
+        return WebSocketUpgrader(maxFrameSize: maxFrameSize, shouldUpgrade: { head in
             let req = HTTPRequest(
                 method: head.method,
                 url: head.uri,

--- a/Sources/WebSocket/WebSocketHandler.swift
+++ b/Sources/WebSocket/WebSocketHandler.swift
@@ -16,15 +16,11 @@ private final class WebSocketHandler: ChannelInboundHandler {
     /// See `ChannelInboundHandler`.
     typealias OutboundOut = WebSocketFrame
 
-    /// If true, a close has been sent from this decoder.
-    private var awaitingClose: Bool
-
     /// `WebSocket` to handle the incoming events.
     private var webSocket: WebSocket
 
     /// Creates a new `WebSocketEventDecoder`
     init(webSocket: WebSocket) {
-        self.awaitingClose = false
         self.webSocket = webSocket
     }
 
@@ -36,6 +32,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
     /// See `ChannelInboundHandler`.
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var frame = self.unwrapInboundIn(data)
+        print("READ: \(frame)")
         switch frame.opcode {
         case .connectionClose: receivedClose(ctx: ctx, frame: frame)
         case .ping: pong(ctx: ctx, frame: frame)
@@ -61,18 +58,25 @@ private final class WebSocketHandler: ChannelInboundHandler {
 
     /// Closes gracefully.
     private func receivedClose(ctx: ChannelHandlerContext, frame: WebSocketFrame) {
+        /// Parse the close frame.
+        var data = frame.unmaskedData
+        if let closeCode = data.readInteger(as: UInt16.self)
+            .map(Int.init)
+            .flatMap(WebSocketErrorCode.init(codeNumber:))
+        {
+            webSocket.onCloseCodeCallback(closeCode)
+        }
+
         // Handle a received close frame. In websockets, we're just going to send the close
         // frame and then close, unless we already sent our own close frame.
-        if awaitingClose {
+        if webSocket.isClosed {
             // Cool, we started the close and were waiting for the user. We're done.
             ctx.close(promise: nil)
         } else {
             // This is an unsolicited close. We're going to send a response frame and
             // then, when we've sent it, close up shop. We should send back the close code the remote
             // peer sent us, unless they didn't send one at all.
-            var data = frame.unmaskedData
-            let closeDataCode = data.readSlice(length: 2) ?? ctx.channel.allocator.buffer(capacity: 0)
-            let closeFrame = WebSocketFrame(fin: true, opcode: .connectionClose, data: closeDataCode)
+            let closeFrame = WebSocketFrame(fin: true, opcode: .connectionClose, data: data)
             _ = ctx.write(wrapOutboundOut(closeFrame)).always {
                 _ = ctx.close(promise: nil)
             }
@@ -103,6 +107,6 @@ private final class WebSocketHandler: ChannelInboundHandler {
         _ = ctx.write(self.wrapOutboundOut(frame)).then {
             ctx.close(mode: .output)
         }
-        awaitingClose = true
+        webSocket.isClosed = true
     }
 }

--- a/Sources/WebSocket/WebSocketHandler.swift
+++ b/Sources/WebSocket/WebSocketHandler.swift
@@ -32,7 +32,6 @@ private final class WebSocketHandler: ChannelInboundHandler {
     /// See `ChannelInboundHandler`.
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
         var frame = self.unwrapInboundIn(data)
-        print("READ: \(frame)")
         switch frame.opcode {
         case .connectionClose: receivedClose(ctx: ctx, frame: frame)
         case .ping: pong(ctx: ctx, frame: frame)

--- a/Tests/WebSocketTests/WebSocketTests.swift
+++ b/Tests/WebSocketTests/WebSocketTests.swift
@@ -33,7 +33,7 @@ class WebSocketTests: XCTestCase {
     func testServer() throws {
         let group = MultiThreadedEventLoopGroup(numThreads: 8)
 
-        let ws = WebSocket.httpProtocolUpgrader(shouldUpgrade: { req in
+        let ws = HTTPServer.webSocketUpgrader(shouldUpgrade: { req in
             if req.url.path == "/deny" {
                 return nil
             }


### PR DESCRIPTION
- [x] adds `onCloseCode(...)` method to `WebSocket`.
- [x] adds `close(code:)` overload to `WebSocket` close method.
- [ ] remove debug print
- [x] fixes #3 
- [x] adds `maxFrameSize` param to server protocol upgrader.
- [x] fixes #4 
- [ ] randomly generate seckey