### PR TITLE
Support of masked frames

### DIFF
--- a/Sources/WebSocket/WebSocket+Client.swift
+++ b/Sources/WebSocket/WebSocket+Client.swift
@@ -98,7 +98,7 @@ private final class WebSocketClientUpgrader: HTTPClientProtocolUpgrader {
 
     /// See `HTTPClientProtocolUpgrader`.
     func upgrade(ctx: ChannelHandlerContext, upgradeResponse: HTTPResponseHead) -> Future<WebSocket> {
-        let webSocket = WebSocket(channel: ctx.channel)
+        let webSocket = WebSocket(channel: ctx.channel, mode: .client)
         return ctx.channel.pipeline.addHandlers(WebSocketFrameEncoder(), WebSocketFrameDecoder(maxFrameSize: maxFrameSize), first: false).then {
             return ctx.channel.pipeline.add(webSocket: webSocket)
         }.map(to: WebSocket.self) {

--- a/Sources/WebSocket/WebSocket+Server.swift
+++ b/Sources/WebSocket/WebSocket+Server.swift
@@ -48,7 +48,7 @@ extension HTTPServer {
                 headers: head.headers
             )
             req.channel = channel
-            let webSocket = WebSocket(channel: channel)
+            let webSocket = WebSocket(channel: channel, mode: .server)
             return channel.pipeline.add(webSocket: webSocket).map {
                 onUpgrade(webSocket, req)
             }


### PR DESCRIPTION
RFC 6455 Section 5.1
To avoid confusing network intermediaries (such as intercepting proxies) and for security reasons that are further, a client MUST mask all frames that it sends to the server.

The server MUST close the connection upon receiving a frame that is not masked.
A server MUST NOT mask any frames that it sends to the client.
A client MUST close a connection if it detects a masked frame.
