### PR TITLE
Set WebSocketFrame's mask key parameter

### DIFF
--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -1,3 +1,5 @@
+import Crypto
+
 /// Represents a client connected via WebSocket protocol.
 /// Use this to receive text/data frames and send responses.
 ///
@@ -191,11 +193,23 @@ public final class WebSocket: BasicWorker {
         let data = data.convertToData()
         var buffer = channel.allocator.buffer(capacity: data.count)
         buffer.write(bytes: data)
-        send(WebSocketFrame(fin: true, opcode: opcode, data: buffer), promise: promise)
+        let maskKey = WebSocketMaskingKey.generateRandom()
+        send(WebSocketFrame(fin: true, opcode: opcode, maskKey: maskKey, data: buffer), promise: promise)
     }
 
     /// Private send that accepts a raw `WebSocketFrame`.
     private func send(_ frame: WebSocketFrame, promise: Promise<Void>?) {
         channel.writeAndFlush(frame, promise: promise)
     }
+}
+
+fileprivate extension WebSocketMaskingKey {
+    
+    static func generateRandom() -> WebSocketMaskingKey? {
+        let randomValue: UnsafeBufferPointer? = try? CryptoRandom()
+            .generateData(count: 4)
+            .withByteBuffer { $0 }
+        return randomValue.flatMap(WebSocketMaskingKey.init)
+    }
+    
 }


### PR DESCRIPTION
Fix https://github.com/vapor/websocket/issues/18.

This PR sets the WebSocketFrame mask key value required by the WebSocket spec as discussed in https://github.com/vapor/websocket/issues/7