### PR TITLE
Masking `pong` and `close` frames 

### DIFF
--- a/Sources/WebSocket/WebSocketHandler.swift
+++ b/Sources/WebSocket/WebSocketHandler.swift
@@ -84,15 +84,13 @@ private final class WebSocketHandler: ChannelInboundHandler {
 
     /// Sends a pong frame in response to ping.
     private func pong(ctx: ChannelHandlerContext, frame: WebSocketFrame) {
-        var frameData = frame.data
-        let maskingKey = frame.maskKey
-
-        if let maskingKey = maskingKey {
-            frameData.webSocketUnmask(maskingKey)
-        }
-
-        let responseFrame = WebSocketFrame(fin: true, opcode: .pong, data: frameData)
-        ctx.write(self.wrapOutboundOut(responseFrame), promise: nil)
+        let responseFrame = WebSocketFrame(
+                fin: true,
+                opcode: .pong,
+                maskKey: webSocket.mode.makeMaskKey(),
+                data: frame.data
+        )
+        ctx.writeAndFlush(self.wrapOutboundOut(responseFrame), promise: nil)
     }
 
     /// Closes the connection with error frame.
@@ -102,7 +100,14 @@ private final class WebSocketHandler: ChannelInboundHandler {
         var data = ctx.channel.allocator.buffer(capacity: 2)
         let error = WebSocketErrorCode.protocolError
         data.write(webSocketErrorCode: error)
-        let frame = WebSocketFrame(fin: true, opcode: .connectionClose, data: data)
+
+        let frame = WebSocketFrame(
+                fin: true,
+                opcode: .connectionClose,
+                maskKey: webSocket.mode.makeMaskKey(),
+                data: data
+        )
+
         _ = ctx.write(self.wrapOutboundOut(frame)).then {
             ctx.close(mode: .output)
         }


### PR DESCRIPTION
### Mask **pong** and **close** frames as says in [rfc6455](https://tools.ietf.org/html/rfc6455#section-5.3)

### Motivation
Some servers e.g. [gorilla/websocket](https://github.com/gorilla/websocket/blob/master/conn.go#L850) **close connection** and send error to this client, when receives `.pong` which is **not** masked.

from the RFC:
```
To avoid confusing network intermediaries (such as
   intercepting proxies) and for security reasons that are further
   discussed in Section 10.3, a client MUST mask all frames that it
   sends to the server (see Section 5.3 for further details).  (Note
   that masking is done whether or not the WebSocket Protocol is running
   over TLS.)  The server MUST close the connection upon receiving a
   frame that is not masked.
```

So we need to mask:
 - Pong frames 
 - Close frames - [close frames sent from client to server must be masked as per
   Section 5.3.](https://tools.ietf.org/html/rfc6455#section-5.5.1)

### Result
Pong and close frames masked.


