### PR TITLE
Fix broken testServerContinuation() test

### DIFF
--- a/Tests/WebSocketTests/WebSocketTests.swift
+++ b/Tests/WebSocketTests/WebSocketTests.swift
@@ -84,7 +84,6 @@ class WebSocketTests: XCTestCase {
         let ws = HTTPServer.webSocketUpgrader(shouldUpgrade: { req in
             return [:]
         }, onUpgrade: { ws, req in
-            ws.send(req.url.path)
             ws.onText { ws, string in
                 ws.send(string.reversed())
             }


### PR DESCRIPTION
Simple fix, not sure why that `ws.send` is in the test, makes no sense (to me) to be there.

Thanks for this library (I'm looking forward to the excuse to use Vapor proper at work).